### PR TITLE
Fix broken ipyleaflet map selection

### DIFF
--- a/opentnsim/example.py
+++ b/opentnsim/example.py
@@ -160,7 +160,7 @@ def plot_locations(graph, locations, center, zoom):
     ]
 
     map = ipyleaflet.Map(
-        basemap=ipyleaflet.basemaps.OpenStreetMap.BlackAndWhite,
+        basemap=ipyleaflet.basemaps.OpenStreetMap.Mapnik,
         center=center,
         zoom=zoom,
     )


### PR DESCRIPTION
Basemap `ipyleaflet.basemaps.OpenStreetMap.BlackAndWhite` is not working anymore. Changed to default `basemap=ipyleaflet.basemaps.OpenStreetMap.Mapnik`.